### PR TITLE
Adding in packages I manage that use the astropy affiliated template

### DIFF
--- a/update-affiliated/helpers_2.py
+++ b/update-affiliated/helpers_2.py
@@ -62,5 +62,10 @@ repositories = sorted(set([
     ('desihub', 'specsim'),
     ('dkirkby', 'speclite'),
     ('matteobachetti', 'srt-single-dish-tools'),
-    ('mhvk', 'baseband')
+    ('mhvk', 'baseband'),
+    ('BEAST-Fitting', 'beast'),
+    ('PAHFIT', 'pypahfit'),
+    ('karllark', 'dust_extinction'),
+    ('karllark', 'dust_attenuation'),
+    ('karllark', 'measure_extinction')
 ]))


### PR DESCRIPTION
Five packages added that use the astropy affiliated template and could use automated PRs to update astropy-helpers.  All these packages should by python 2 and 3 compatible for now - so adding them to the helpers_2.py file.  May change this in the future, but then will create pull requests as needed.