### PR TITLE
Add script to check ci-helpers usage

### DIFF
--- a/ci_helpers_usage.py
+++ b/ci_helpers_usage.py
@@ -1,0 +1,27 @@
+import requests
+from github import Github
+from common import get_credentials
+
+username, password = get_credentials()
+gh = Github(username, password)
+
+gh_search_result = gh.search_code('filename:.travis.yml "astropy/ci-helpers"')
+
+gh_repo = []
+gh_name = []
+
+for i in gh_search_result:
+    gh_repo.append(i.repository.full_name)
+    gh_name.append(i.repository.name)
+
+gh_name = set(gh_name)
+
+pypi_name = []
+
+for i in gh_name:
+    response = requests.get("http://pypi.python.org/pypi/{}/json".format(i))
+    if response.status_code == 200:
+        pypi_name.append(i)
+
+
+print(len(gh_name), len(pypi_name))


### PR DESCRIPTION
The question of ci-helpers usage came up now several times, so adding this snippet may be useful in the future, too.

Obviously this uses the over simplified assumption that if the repo name is mentioned in the travis configuration then it's used.