### PR TITLE
Remove the package-template from the auto update list

### DIFF
--- a/update-packages/helpers_2.py
+++ b/update-packages/helpers_2.py
@@ -26,7 +26,6 @@ repositories = sorted(set([
     ('hamogu', 'astrospec'),
     ('astropy', 'astropy-healpix'),
     ('astropy', 'saba'),
-    ('astropy', 'package-template'),
     ('spacetelescope', 'astroimtools'),
     ('spacetelescope', 'synphot_refactor'),
     ('spacetelescope', 'stsynphot_refactor'),


### PR DESCRIPTION
As changes should be done there differently on the cookiecutter branch rather than in the rendered version of master