### PR TITLE
Remove hamogu/astrospec

### DIFF
--- a/update-packages/helpers_2.py
+++ b/update-packages/helpers_2.py
@@ -20,7 +20,6 @@ repositories = sorted(set([
     ('pyspeckit', 'pyspeckit'),
     ('linetools', 'linetools'),
     ('astropy', 'regions'),
-    ('hamogu', 'astrospec'),
     ('astropy', 'astropy-healpix'),
     ('astropy', 'saba'),
     ('spacetelescope', 'astroimtools'),


### PR DESCRIPTION
Astrospec was meant as an alternative implementation for specutils at a time when that package was langushing. There is still stuff in astrospec that I plan to port to specutils at some point, but it's only a few functions and I don't maintain astrospec as a real "package" any longer.