### PR TITLE
imexam no longer uses astropy_helpers

### DIFF
--- a/update-packages/helpers_2.py
+++ b/update-packages/helpers_2.py
@@ -16,7 +16,6 @@ repositories = sorted(set([
     ('pyspeckit', 'pyspeckit'),
     ('linetools', 'linetools'),
     ('astropy', 'astropy-healpix'),
-    ('spacetelescope', 'imexam'),
     ('desihub', 'specsim'),
     ('dkirkby', 'speclite'),
     ('BEAST-Fitting', 'beast'),


### PR DESCRIPTION
This PR removes imexam from the auto-pr list 