### PR TITLE
Make script to work with local changelog file

### DIFF
--- a/pr_consistency/3.find_pr_changelog_section.py
+++ b/pr_consistency/3.find_pr_changelog_section.py
@@ -26,7 +26,14 @@ NAME = os.path.basename(REPOSITORY)
 print("The repository this script currently works with is '{}'.\n"
       .format(REPOSITORY))
 
-CHANGELOG = 'https://raw.githubusercontent.com/{}/master/{}'.format(REPOSITORY, CHANGELOG_NAME)
+if os.environ.get('LOCAL_CHANGELOG'):
+    CHANGELOG = os.environ['LOCAL_CHANGELOG']
+    with open(CHANGELOG) as f:
+        changelog_lines = f.readlines()
+else:
+    CHANGELOG = 'https://raw.githubusercontent.com/{}/master/{}'.format(REPOSITORY, CHANGELOG_NAME)
+    changelog_lines = requests.get(CHANGELOG).text.splitlines()
+
 TMPDIR = tempfile.mkdtemp()
 
 BLOCK_PATTERN = re.compile('[[(]#[0-9#, ]+[])]')
@@ -54,7 +61,7 @@ previous = None
 
 new_changelog_format = False
 
-for line in requests.get(CHANGELOG).text.splitlines():
+for line in changelog_lines:
     if '=======' in line:
         new_changelog_format = True
     if '=======' in line or (not new_changelog_format and '-------' in line):


### PR DESCRIPTION
When doing a release with bugfix branches it makes more sense to use the local changelog file (e.g. on the bugfix branch) to check for consistency rather than the out-of-sync version on the remote.