### PR TITLE
tweak wording at end of review

### DIFF
--- a/documents/affiliated_package_review_process.md
+++ b/documents/affiliated_package_review_process.md
@@ -278,8 +278,18 @@ respond to the comments and/or address any of them.
 
 *In all cases:*
 
+
 If you have any follow-up questions or disagree with any of the comments above,
-leave a comment and we can discuss it here. At any point in future you can
-request a re-review of the package if you believe any of the scores should be
-updated - contact the coordination committee, and we’ll do a new review.
+leave a comment and we can discuss it here. Or if this has been merged but you
+want to suggest a change to the review status, you can open an PR in this repo
+updating your package's review status, along with an explanation of why you
+think it should be changed.
+
+At any point in future you or someone else can
+request a full re-review of the package if you believe substantial changes have been
+made and many of the scores should be updated - contact the coordination committee,
+and we’ll do a new review.
+
+
+
 ```


### PR DESCRIPTION
In astropy/astropy.github.com#315 I realized our default wording at the end of the review process is a bit odd for an accepted-with-orange review, because we merge the PR but still ask for feedback in the thread.  So I added a bit here that basically just says "make a new PR to update this to trigger more discussion".  I think that's more realistic to keep up with - do you agree, @astrofrog?